### PR TITLE
Added configurable region scope for error highlighting

### DIFF
--- a/SublimeSBT.sublime-settings
+++ b/SublimeSBT.sublime-settings
@@ -18,6 +18,11 @@
 	// "dot", "outline", or "both".
 	"mark_style": "both",
 
+	// Region scope, which is used to highlight errors ouline.
+	// If you use "invalid.illegal", most likely it will be red,
+	// but it depends on your color scheme.
+	"error_scope": "source.scala",
+
 	// The color scheme to use for the output panel. Only the default
 	// foreground and background colors are used.
 	"color_scheme": "Packages/Color Scheme - Default/Monokai.tmTheme"

--- a/highlighter.py
+++ b/highlighter.py
@@ -6,7 +6,6 @@ class CodeHighlighter(object):
     def __init__(self, settings):
         self.settings = settings
         self.region_key = 'sublimesbt_error_reporting'
-        self.region_scope = 'source.scala'
         self.status_key = 'SBT'
         self._update_highlight_args()
         settings.add_on_change(self._update_highlight_args)
@@ -42,6 +41,7 @@ class CodeHighlighter(object):
             return line
 
     def _update_highlight_args(self):
+        self.region_scope = self.settings.get('error_scope')
         style = self.settings.get('mark_style')
         self._highlight_args = self._create_highlight_args(style)
 


### PR DESCRIPTION
I like, when errors are highlighted in red, because it's more noticeable and more fits to things, which are wrong :smiley: May be it will be useful for somebody else — I've just added a setting.
