### PR TITLE
Cause the filter object to be evaluated instead of returning the object

### DIFF
--- a/project.py
+++ b/project.py
@@ -81,7 +81,7 @@ class Project(object):
         return glob(os.path.join(folder, 'project', '*.scala'))
 
     def _play_build_files(self, folder):
-        return filter(self._is_play_build, self._scala_build_files(folder))
+        return list(filter(self._is_play_build, self._scala_build_files(folder)))
 
     def _is_play_build(self, build_path):
         try:


### PR DESCRIPTION
The change you made on line 84 actually breaks functionality and any boolean expression written against the function to return true.  This is caused by the fact that the filter object itself is returned.  What you want is the following:

```
list(filter(self._is_play_build, self._scala_build_files(folder)))
```

I've fixed it in this branch.
