### PR TITLE
Fix for issue #9

### DIFF
--- a/sbtrunner.py
+++ b/sbtrunner.py
@@ -47,13 +47,17 @@ class SbtRunner(OnePerWindow):
 
     def stop_sbt(self):
         if self.is_sbt_running():
+            self._close_sbt()
             self._proc.terminate()
 
     def kill_sbt(self):
         if self.is_sbt_running():
-            # Closing stdin sends an EOF to SBT, telling it to shutdown
-            self._proc.stdin.close()
+            self._close_sbt()
             self._proc.kill()
+
+    def _close_sbt(self):
+        # Closing stdin sends an EOF to SBT, telling it to shutdown
+        self._proc.stdin.close()
 
     def is_sbt_running(self):
         return (self._proc is not None) and (self._proc.returncode is None)


### PR DESCRIPTION
I think the problem had to do with the fact that the subprocess started was actually bash, not sbt directly. So killing it without first sending EOF to sbt merely disconnected sbt.

The fix here simple closes stdin first. This tells sbt to shutdown. Then the process is killed.

Fix for issue #9 

Note that I did not test on Windows.
