### PR TITLE
Fix for issue #11

### DIFF
--- a/errormarker.py
+++ b/errormarker.py
@@ -41,7 +41,11 @@ class ErrorMarker(object):
         for view in self._window.views():
             self._highlighter.clear(view)
 
+    @delayed(0)
     def update_status(self):
+        self.update_status_now()
+
+    def update_status_now(self):
         for view in maybe(self._window.active_view()):
             self._highlighter.set_status_message(view, self._status_message(view))
 

--- a/errorreporter.py
+++ b/errorreporter.py
@@ -37,3 +37,6 @@ class ErrorReporter(object):
 
     def update_status(self):
         self._marker.update_status()
+
+    def update_status_now(self):
+        self._marker.update_status_now()

--- a/sublimesbt.py
+++ b/sublimesbt.py
@@ -266,7 +266,7 @@ class SbtListener(sublime_plugin.EventListener):
             SbtView(view.window()).update_writability()
         else:
             for reporter in maybe(self._reporter(view)):
-                reporter.update_status()
+                reporter.update_status_now()
 
     def on_activated(self, view):
         for reporter in maybe(self._reporter(view)):


### PR DESCRIPTION
After a long time of commenting different parts of the `on_selection_modified` call tree out, I determined that removing the delay `ErrorMarker.update_status` got rid of the issue. Note that even `print`ing inside `on_selection_modified` would trigger, so Sublime is obviously really sensitive to something here.

Fixes issue #11 
