### PR TITLE
Add column position to error objects and position cursor at correct columns

### DIFF
--- a/sbterror.py
+++ b/sbterror.py
@@ -12,9 +12,9 @@ class SbtError(object):
     def __init__(self, project, filename, line, message, error_type, extra_lines):
         self.line = int(line)
         if len(extra_lines) > 0 and re.match(r' *^', extra_lines[-1]):
-            self.column = len(extra_lines[-1])
+            self.column_spec = ':%i' % len(extra_lines[-1])
         else:
-            self.column = 1
+            self.column_spec = ''
         self.message = message
         self.error_type = error_type
         self.__finished = Event()
@@ -36,10 +36,10 @@ class SbtError(object):
         return self.__text
 
     def list_item(self):
-        return [self.message, '%s:%i:%i' % (self.relative_path, self.line, self.column)]
+        return [self.message, '%s:%i%s' % (self.relative_path, self.line, self.column_spec)]
 
     def encoded_position(self):
-        return '%s:%i:%i' % (self.filename, self.line, self.column)
+        return '%s:%i%s' % (self.filename, self.line, self.column_spec)
 
     @delayed(0)
     def __finish(self, project, filename, extra_lines):


### PR DESCRIPTION
This change means that when you go to an error your new position will be at the correct column as well as at the correct line. It uses the pointer line "         ^" generated by the Scala compiler, if it's there. If it's not there (e.g., it's a failure from a test) position at column 1 as before.
