### PR TITLE
History init

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,21 @@ Project*** menu entry and putting settings in a "SublimeSBT" object inside of
         }
     }
 
+**history**
+
+  - An array that contains commands that should be added to the command
+    history when a project is opened.
+
 **history_length**
 
   - The maximum number of unique commands to keep in the command history.
     The default setting is 20.
+
+Project-Specific Configuring
+----------------------------
+If the file `.SublimeSBT_history` exists at the top level of a project, each
+line of that file will be added to the command history when the project is
+opened.
 
 Contributors
 ------------

--- a/sbtrunner.py
+++ b/sbtrunner.py
@@ -23,7 +23,7 @@ class SbtRunner(OnePerWindow):
     def __init__(self, window):
         self._project = Project(window)
         self._proc = None
-        self._history = []
+        self.init_history()
 
     def project_root(self):
         return self._project.project_root()
@@ -69,6 +69,17 @@ class SbtRunner(OnePerWindow):
                    'You may need to specify the full path to your sbt command.'
                    % cmdline[0])
             sublime.error_message(msg)
+
+    def init_history(self):
+        self._history = []
+        if self.project_root():
+            path = os.path.join(self.project_root(), '.SublimeSBT_history')
+            if os.path.exists(path):
+                for line in open(path):
+                    self._history.append(line.rstrip('\n\r'))
+            global_cmds = self._project.settings.get('history') or []
+            for cmd in global_cmds:
+                self._history.append(cmd)
 
     def add_to_history(self, input):
         if input != '' and not input.isspace ():


### PR DESCRIPTION
The history feature is working well, but I've found it sometimes annoying to have to manually enter some complex commands each time I start up work in a project. These changes support two ways of specifying initial commands for the history.