### PR TITLE
Column tag for sbt 1.0.0 - fixes ShowNextError.

### DIFF
--- a/outputmon.py
+++ b/outputmon.py
@@ -73,7 +73,7 @@ class ErrorParser(AbstractErrorParser):
 
     @classmethod
     def start(cls, project, line):
-        for m in maybe(re.match(r'\[(error|warn)\]\s+(.+):(\d+):\s+(.+)$', line)):
+        for m in maybe(re.match(r'^\[(error|warn)\]\s+(.+?):(\d+):(?:(\d+):)?\s+(.+)$', line)):
             yield cls(project,
                       line=line,
                       label=m.group(1),

--- a/outputmon.py
+++ b/outputmon.py
@@ -79,7 +79,7 @@ class ErrorParser(AbstractErrorParser):
                       label=m.group(1),
                       filename=m.group(2),
                       lineno=int(m.group(3)),
-                      message=m.group(4))
+                      message=m.group(5))
 
     def __init__(self, project, line, label, filename, lineno, message):
         AbstractErrorParser.__init__(self, project, line, filename, lineno, message)


### PR DESCRIPTION
SBT 1.0.0 has slightly different error output than 0.13.x which also includes column number. ie, instead of 
`[error]  C:\Me\MyPath\myFile.scala:18: not found: value getaa`
it shows 
`[error]  C:\Me\MyPath\myFile.scala:18:22: not found: value getaa`
This means that ShowNextError will try to open the (non-existent) file `myFile.scala:18` rather than `myFile.scala`. This regex change fixes that, and works whether or not the column is included.